### PR TITLE
Tests optimisations, expose task properties and cleaning up temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore Gradle project-specific cache directory
+.gradle/
+
+# Ignore Gradle build output directory
+build/

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Gradle automatically applies [init scripts](https://docs.gradle.org/current/user
      **mandatory settings:**
      * `gradleVersion` - base Gradle wrapper version
      * `customDistributionVersion` - custom distribution version (`project.version` is used by default)
-     * `customDistributionFileNameMapper` - a property of type [CustomDistributionNameMapper](./src/main/kotlin/tech/harmonysoft/oss/gradle/dist/config/CustomDistributionNameMapper.kt) which generates resulting custom distribution file name for the given parameters. *Note: it's necessary to specify this property or 'distributionNameMapper' property. It's an error to define the both/none of them*
+     * `customDistributionFileNameMapper` - a property of type [CustomDistributionNameMapper](./src/main/kotlin/tech/harmonysoft/oss/gradle/dist/config/CustomDistributionNameMapper.kt) which generates resulting custom distribution file name for the given parameters. *Note: it's necessary to specify this property or `distributionNameMapper` property. It's an error to define the both/none of them*
        * `gradleVersion` - base gradle distribution version as defined above
        * `customDistributionVersion` - custom distribution mixing version as defined above
        * `gradleDistributionType` - gradle distribution type as defined below
@@ -118,10 +118,13 @@ Gradle automatically applies [init scripts](https://docs.gradle.org/current/user
            }
        }
        ```
-     *Note: it's necessary to specify this property or 'customDistributionFileNameMapper' property. It's an error to define the both/none of them*
+       *Note: it's necessary to specify this property or `customDistributionFileNameMapper` property. It's an error to define the both/none of them*
+    
+    * `initScriptsSourceDir` - a path to the directory where your initialization scripts are located (see below docs for more details). The path to the directory must be set, and the pointed directory must exist. The default path is `src/main/resources/init.d`.
      
      **optional settings:**
-     * `gradleDistributionType` - allows to specify base Gradle distribution type. `bin` and `all` [are available](https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:adding_wrapper) at the moment, `bin` is used by default  
+     * `gradleDistributionType` - allows to specify base Gradle distribution type. `bin` and `all` [are available](https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:adding_wrapper) at the moment, `bin` is used by default
+     * `utilityScriptsSourceDir` - a path to the directory where your utility scripts and replacements are located (see below docs for more details). The path to the directory is optional, but the pointed directory must exist. The default path is `src/main/resources/include`.
      * `skipContentExpansionFor` - the plugin by default expands content of the files included into custom Gradle distribution by default (see below). That might cause a problem if we want to add some binary file like `*.jar` or `*.so`. This property holds a list of root paths relative to `init.d` which content shouldn't be expanded.  
        Example: consider the following project structure:
        ```
@@ -269,6 +272,16 @@ Gradle automatically applies [init scripts](https://docs.gradle.org/current/user
     ```
     
     The distribution(s) are located in the `build/gradle-dist`
+
+6. In addition, if you need, you can configure the properties of the `buildGradleDist` task, such as the path to the directory where downloaded Gradle distributions and built custom Gradle distributions should be located.  You can do this as follows:
+    ```groovy
+    import tech.harmonysoft.oss.gradle.dist.BuildCustomGradleDistributionTask
+   
+    tasks.named('buildGradleDist', BuildCustomGradleDistributionTask) {
+        gradleDownloadDir = project.layout.buildDirectory.dir('own-gradle-download') 
+        customDistributionOutputDir = project.layout.buildDirectory.dir('own-gradle-dist') 
+    }
+    ```
 
 ### Configure Client Project
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Gradle automatically applies [init scripts](https://docs.gradle.org/current/user
  3. Specify target settings in the `gradleDist {}` block.  
      **mandatory settings:**
      * `gradleVersion` - base Gradle wrapper version
-     * `customDistributionVersion` - custom distribution version
+     * `customDistributionVersion` - custom distribution version (`project.version` is used by default)
      * `customDistributionFileNameMapper` - a property of type [CustomDistributionNameMapper](./src/main/kotlin/tech/harmonysoft/oss/gradle/dist/config/CustomDistributionNameMapper.kt) which generates resulting custom distribution file name for the given parameters. *Note: it's necessary to specify this property or 'distributionNameMapper' property. It's an error to define the both/none of them*
        * `gradleVersion` - base gradle distribution version as defined above
        * `customDistributionVersion` - custom distribution mixing version as defined above

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,25 @@ kotlin {
     jvmToolchain(8)
 }
 
+testing {
+    suites {
+        withType<JvmTestSuite> {
+            targets {
+                all {
+                    testTask.configure {
+                        // Share Gradle downloads between tests runs for much
+                        // faster feedback
+                        systemProperty(
+                            "gradleDistTest.downloadRootDir",
+                            File(temporaryDir, "gradle-download")
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
 gradlePlugin {
     website = "https://gradle-dist.oss.harmonysoft.tech/"
     vcsUrl = "https://github.com/denis-zhdanov/custom-gradle-dist-gradle-plugin"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,25 +12,6 @@ kotlin {
     jvmToolchain(8)
 }
 
-testing {
-    suites {
-        withType<JvmTestSuite> {
-            targets {
-                all {
-                    testTask.configure {
-                        // Share Gradle downloads between tests runs for much
-                        // faster feedback
-                        systemProperty(
-                            "gradleDistTest.downloadRootDir",
-                            File(temporaryDir, "gradle-download")
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
 gradlePlugin {
     website = "https://gradle-dist.oss.harmonysoft.tech/"
     vcsUrl = "https://github.com/denis-zhdanov/custom-gradle-dist-gradle-plugin"

--- a/sample/multiple-custom-gradle-distributions/README.md
+++ b/sample/multiple-custom-gradle-distributions/README.md
@@ -17,10 +17,10 @@ Note: a cool feature of init scripts is that we can apply Gradle plugins from th
 ## In Action
 
 1. Build custom distribution  
-    `pushd custom-distribution; ./gradlew build; popd`
+    `pushd custom-distribution; ./gradlew buildGradleDist; popd`
 2. Run the client project  
     `pushd client-project; ./gradlew bootRun; popd`  
-3. Call a web server server started by the client project and ensure that it works  
+3. Call a web server started by the client project and ensure that it works  
     ```
     curl 127.0.0.1:8080/ping
     Hi there!

--- a/sample/multiple-custom-gradle-distributions/client-project/gradle/wrapper/gradle-wrapper.properties
+++ b/sample/multiple-custom-gradle-distributions/client-project/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=../../../custom-distribution/build/gradle-dist/gradle-8.4-test-multi-distributions-1.0-service.zip
+distributionUrl=../../../custom-distribution/build/gradle-dist/gradle-8.4-test-multi-distributions-1.0-service-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sample/multiple-custom-gradle-distributions/custom-distribution/build.gradle
+++ b/sample/multiple-custom-gradle-distributions/custom-distribution/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'tech.harmonysoft.oss.custom-gradle-dist-plugin' version '1.9'
+    id 'tech.harmonysoft.oss.custom-gradle-dist-plugin' version '1.17'
 }
 
 gradleDist {

--- a/sample/multiple-custom-gradle-distributions/custom-distribution/settings.gradle
+++ b/sample/multiple-custom-gradle-distributions/custom-distribution/settings.gradle
@@ -1,1 +1,9 @@
+pluginManagement {
+    includeBuild('../../../') {
+        logger.warn(
+            'Replaced indicated version of the Plugin with the current implementation from the root project directory.'
+        )
+    }
+}
+
 rootProject.name = 'multiple-custom-gradle-distributions'

--- a/sample/single-custom-gradle-distribution/README.md
+++ b/sample/single-custom-gradle-distribution/README.md
@@ -15,10 +15,10 @@ This is an example of using custom Gradle distribution for projects with the sam
 ## In Action
 
 1. Build custom distribution  
-    `pushd custom-distribution; ./gradlew build; popd`
+    `pushd custom-distribution; ./gradlew buildGradleDist; popd`
 2. Run the client project  
     `pushd client-project; ./gradlew bootRun; popd`  
-3. Call a web server server started by the client project and ensure that it works  
+3. Call a web server started by the client project and ensure that it works  
     ```
     curl 127.0.0.1:8080/ping
     Hi there!

--- a/sample/single-custom-gradle-distribution/client-project/gradle/wrapper/gradle-wrapper.properties
+++ b/sample/single-custom-gradle-distribution/client-project/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=../../../custom-distribution/build/gradle-dist/gradle-8.4-test-single-distribution-1.0.zip
+distributionUrl=../../../custom-distribution/build/gradle-dist/gradle-8.4-test-single-distribution-1.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sample/single-custom-gradle-distribution/custom-distribution/build.gradle
+++ b/sample/single-custom-gradle-distribution/custom-distribution/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'tech.harmonysoft.oss.custom-gradle-dist-plugin' version '1.9'
+    id 'tech.harmonysoft.oss.custom-gradle-dist-plugin' version '1.17'
 }
 
 gradleDist {

--- a/sample/single-custom-gradle-distribution/custom-distribution/settings.gradle
+++ b/sample/single-custom-gradle-distribution/custom-distribution/settings.gradle
@@ -1,1 +1,9 @@
+pluginManagement {
+    includeBuild('../../../') {
+        logger.warn(
+            'Replaced indicated version of the Plugin with the current implementation from the root project directory.'
+        )
+    }
+}
+
 rootProject.name = 'single-custom-gradle-distribution'

--- a/src/main/kotlin/tech/harmonysoft/oss/gradle/dist/BuildCustomGradleDistributionTask.kt
+++ b/src/main/kotlin/tech/harmonysoft/oss/gradle/dist/BuildCustomGradleDistributionTask.kt
@@ -36,7 +36,6 @@ abstract class BuildCustomGradleDistributionTask : DefaultTask() {
     @get:InputDirectory
     abstract val includeRootDir: DirectoryProperty
 
-    @get:Optional
     @get:InputDirectory
     abstract val extensionsRootDir: DirectoryProperty
 
@@ -50,9 +49,9 @@ abstract class BuildCustomGradleDistributionTask : DefaultTask() {
         project.layout.projectDirectory.dir("src/main/resources/include").let {
             if (it.asFile.exists()) includeRootDir.convention(it)
         }
-        project.layout.projectDirectory.dir("src/main/resources/init.d").let {
-            if (it.asFile.exists()) extensionsRootDir.convention(it)
-        }
+        extensionsRootDir.convention(
+            project.layout.projectDirectory.dir("src/main/resources/init.d")
+        )
         customDistributionsRootDir.convention(
             project.layout.buildDirectory.dir("gradle-dist")
         )
@@ -150,8 +149,8 @@ abstract class BuildCustomGradleDistributionTask : DefaultTask() {
     }
 
     private fun getDistributions(): Collection<String> {
-        val extensionsRootDir = this.extensionsRootDir.orNull?.asFile
-        val childDirectories = extensionsRootDir?.listFiles(FileFilter { it.isDirectory })
+        val extensionsRootDir = this.extensionsRootDir.get().asFile
+        val childDirectories = extensionsRootDir.listFiles(FileFilter { it.isDirectory })
         return if (childDirectories == null || childDirectories.size < 2) {
             project.logger.lifecycle("using a single custom gradle distribution")
             emptyList()
@@ -388,7 +387,9 @@ abstract class BuildCustomGradleDistributionTask : DefaultTask() {
             mapOf("create" to "true")
         )
         .use { zipFileSystem ->
-            extensionsRootDir.orNull?.asFile?.let { extensionsRootDir ->
+            val extensionsRootDir = this.extensionsRootDir.get().asFile
+
+            extensionsRootDir.let { extensionsRootDir ->
                 addToZip(
                     zip = zipFileSystem,
                     includeRootDir = distribution?.let {

--- a/src/main/kotlin/tech/harmonysoft/oss/gradle/dist/BuildCustomGradleDistributionTask.kt
+++ b/src/main/kotlin/tech/harmonysoft/oss/gradle/dist/BuildCustomGradleDistributionTask.kt
@@ -45,10 +45,7 @@ abstract class BuildCustomGradleDistributionTask : DefaultTask() {
 
     init {
         downloadRootDir.convention(
-            project.providers
-                .gradleProperty("gradleDist.downloadRootDir")
-                .flatMap { project.layout.buildDirectory.dir(it) }
-                .orElse(project.layout.buildDirectory.dir("download"))
+            project.layout.buildDirectory.dir("download")
         )
         project.layout.projectDirectory.dir("src/main/resources/include").let {
             if (it.asFile.exists()) includeRootDir.convention(it)

--- a/src/main/kotlin/tech/harmonysoft/oss/gradle/dist/BuildCustomGradleDistributionTask.kt
+++ b/src/main/kotlin/tech/harmonysoft/oss/gradle/dist/BuildCustomGradleDistributionTask.kt
@@ -455,14 +455,18 @@ abstract class BuildCustomGradleDistributionTask : DefaultTask() {
         }
         if (exclusionRule == null) {
             val tempFile = Files.createTempFile("", "${fileToInclude.name}.tmp").toFile()
-            val expandedContent = expand(RichValue(
-                value = fileToInclude.readText(),
-                description = "file ${fileToInclude.name}"
-            )) {
-                replacements[it]
+            try {
+                val expandedContent = expand(RichValue(
+                    value = fileToInclude.readText(),
+                    description = "file ${fileToInclude.name}"
+                )) {
+                    replacements[it]
+                }
+                tempFile.writeText(expandedContent)
+                Files.copy(tempFile.toPath(), to)
+            } finally {
+                tempFile.delete()
             }
-            tempFile.writeText(expandedContent)
-            Files.copy(tempFile.toPath(), to)
         } else {
             project.logger.lifecycle(
                 "skipped content expansion for file $relativePath because of exclusion rule '$exclusionRule'"

--- a/src/main/kotlin/tech/harmonysoft/oss/gradle/dist/BuildCustomGradleDistributionTask.kt
+++ b/src/main/kotlin/tech/harmonysoft/oss/gradle/dist/BuildCustomGradleDistributionTask.kt
@@ -101,7 +101,7 @@ abstract class BuildCustomGradleDistributionTask : DefaultTask() {
     private fun doGetBaseGradleDistribution(extension: CustomGradleDistConfig): File {
         val gradleBaseName = "gradle-${extension.gradleVersion.get()}"
         val gradleZip = "$gradleBaseName-${extension.gradleDistributionType.get()}.zip"
-        val baseGradleArchive = downloadRootDir.map { it.dir(gradleZip) }.get().asFile
+        val baseGradleArchive = downloadRootDir.map { it.file(gradleZip) }.get().asFile
         if (!baseGradleArchive.isFile) {
             val archiveDir = baseGradleArchive.parentFile
             if (!archiveDir.isDirectory) {

--- a/src/main/kotlin/tech/harmonysoft/oss/gradle/dist/BuildCustomGradleDistributionTask.kt
+++ b/src/main/kotlin/tech/harmonysoft/oss/gradle/dist/BuildCustomGradleDistributionTask.kt
@@ -5,7 +5,6 @@ import java.io.FileFilter
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.net.URI
-import java.net.URL
 import java.nio.channels.Channels
 import java.nio.file.FileSystem
 import java.nio.file.FileSystems
@@ -14,64 +13,48 @@ import java.util.Properties
 import java.util.Stack
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.provider.Property
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.tooling.BuildException
 import tech.harmonysoft.oss.gradle.dist.config.CustomGradleDistConfig
+import javax.inject.Inject
 
 @Suppress("LeakingThis")
-abstract class BuildCustomGradleDistributionTask : DefaultTask() {
+abstract class BuildCustomGradleDistributionTask @Inject constructor(
+    @get:Nested val config: CustomGradleDistConfig
+) : DefaultTask() {
 
     @get:Internal
-    abstract val config: Property<CustomGradleDistConfig>
-
-    @get:Internal
-    abstract val downloadRootDir: DirectoryProperty
-
-    @get:Optional
-    @get:InputDirectory
-    abstract val includeRootDir: DirectoryProperty
-
-    @get:InputDirectory
-    abstract val extensionsRootDir: DirectoryProperty
+    abstract val gradleDownloadDir: DirectoryProperty
 
     @get:OutputDirectory
-    abstract val customDistributionsRootDir: DirectoryProperty
+    abstract val customDistributionOutputDir: DirectoryProperty
 
     init {
-        downloadRootDir.convention(
-            project.layout.buildDirectory.dir("download")
+        gradleDownloadDir.convention(
+            project.layout.buildDirectory.dir("gradle-download")
         )
-        project.layout.projectDirectory.dir("src/main/resources/include").let {
-            if (it.asFile.exists()) includeRootDir.convention(it)
-        }
-        extensionsRootDir.convention(
-            project.layout.projectDirectory.dir("src/main/resources/init.d")
-        )
-        customDistributionsRootDir.convention(
+        customDistributionOutputDir.convention(
             project.layout.buildDirectory.dir("gradle-dist")
         )
     }
 
     @TaskAction
     fun build() {
-        val baseDistribution = getBaseGradleDistribution(config.get())
-        val customDistributionsDir = customDistributionsRootDir.get().asFile
+        val baseDistribution = getBaseGradleDistribution(config)
+        val customDistributionsDir = customDistributionOutputDir.get().asFile
         remove(customDistributionsDir)
         Files.createDirectories(customDistributionsDir.toPath())
 
-        val currentConfig = config.get()
         val replacements = prepareReplacements()
         val distributions = getDistributions()
         if (distributions.isEmpty()) {
             prepareCustomDistribution(
                 distribution = null,
                 baseDistribution = baseDistribution,
-                extension = currentConfig,
+                extension = config,
                 replacements = replacements
             )
         } else {
@@ -79,7 +62,7 @@ abstract class BuildCustomGradleDistributionTask : DefaultTask() {
                 prepareCustomDistribution(
                     distribution = distribution,
                     baseDistribution = baseDistribution,
-                    extension = currentConfig,
+                    extension = config,
                     replacements = replacements
                 )
             }
@@ -100,7 +83,7 @@ abstract class BuildCustomGradleDistributionTask : DefaultTask() {
     private fun doGetBaseGradleDistribution(extension: CustomGradleDistConfig): File {
         val gradleBaseName = "gradle-${extension.gradleVersion.get()}"
         val gradleZip = "$gradleBaseName-${extension.gradleDistributionType.get()}.zip"
-        val baseGradleArchive = downloadRootDir.map { it.file(gradleZip) }.get().asFile
+        val baseGradleArchive = gradleDownloadDir.map { it.file(gradleZip) }.get().asFile
         if (!baseGradleArchive.isFile) {
             val archiveDir = baseGradleArchive.parentFile
             if (!archiveDir.isDirectory) {
@@ -123,7 +106,7 @@ abstract class BuildCustomGradleDistributionTask : DefaultTask() {
     }
 
     private fun download(fromUrl: String, toFile: File) {
-        val from = Channels.newChannel(URL(fromUrl).openStream())
+        val from = Channels.newChannel(URI(fromUrl).toURL().openStream())
         project.logger.lifecycle("about to download a gradle distribution from $fromUrl to ${toFile.canonicalPath}")
         FileOutputStream(toFile).channel.use {
             it.transferFrom(from, 0, Long.MAX_VALUE)
@@ -149,8 +132,7 @@ abstract class BuildCustomGradleDistributionTask : DefaultTask() {
     }
 
     private fun getDistributions(): Collection<String> {
-        val extensionsRootDir = this.extensionsRootDir.get().asFile
-        val childDirectories = extensionsRootDir.listFiles(FileFilter { it.isDirectory })
+        val childDirectories = config.initScriptsSourceDir.get().asFile.listFiles(FileFilter { it.isDirectory })
         return if (childDirectories == null || childDirectories.size < 2) {
             project.logger.lifecycle("using a single custom gradle distribution")
             emptyList()
@@ -188,7 +170,8 @@ abstract class BuildCustomGradleDistributionTask : DefaultTask() {
     }
 
     private fun loadReplacementsFromFiles(): Map<String, RichValue> {
-        return includeRootDir.orNull
+        return config.utilityScriptsSourceDir
+            .orNull
             ?.asFile
             ?.listFiles()
             ?.filter {
@@ -325,7 +308,7 @@ abstract class BuildCustomGradleDistributionTask : DefaultTask() {
             gradleDistributionType = extension.gradleDistributionType.get(),
             distributionName = distribution
         ).toString()
-        val customDistributionsDir = customDistributionsRootDir.get().asFile
+        val customDistributionsDir = customDistributionOutputDir.get().asFile
         val result = File(customDistributionsDir, customDistributionFileName)
 
         copyBaseDistribution(baseDistribution, result)
@@ -387,14 +370,12 @@ abstract class BuildCustomGradleDistributionTask : DefaultTask() {
             mapOf("create" to "true")
         )
         .use { zipFileSystem ->
-            val extensionsRootDir = this.extensionsRootDir.get().asFile
-
-            extensionsRootDir.let { extensionsRootDir ->
+            config.initScriptsSourceDir.get().asFile.let { initScriptsSourceDir ->
                 addToZip(
                     zip = zipFileSystem,
                     includeRootDir = distribution?.let {
-                        File(extensionsRootDir, it)
-                    } ?: extensionsRootDir,
+                        File(initScriptsSourceDir, it)
+                    } ?: initScriptsSourceDir,
                     gradleVersion = gradleVersion,
                     pathsToExcludeFromContentExpansion = pathsToExcludeFromContentExpansion,
                     replacements = replacements
@@ -505,6 +486,6 @@ abstract class BuildCustomGradleDistributionTask : DefaultTask() {
 
     companion object {
         private val PATTERN = """\$(\S+)\$""".toRegex()
-        private val REPLACEMENTS_FILE_NAME = "replacements.properties"
+        private const val REPLACEMENTS_FILE_NAME = "replacements.properties"
     }
 }

--- a/src/main/kotlin/tech/harmonysoft/oss/gradle/dist/CustomGradleDistributionPlugin.kt
+++ b/src/main/kotlin/tech/harmonysoft/oss/gradle/dist/CustomGradleDistributionPlugin.kt
@@ -10,11 +10,11 @@ class CustomGradleDistributionPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
         val config = project.extensions.create("gradleDist", CustomGradleDistConfig::class.java)
+        project.tasks.register("buildGradleDist", BuildCustomGradleDistributionTask::class.java) {
+            it.config.set(config)
+        }
         project.afterEvaluate {
             validateAndEnrich(config)
-            project.tasks.register("buildGradleDist", BuildCustomGradleDistributionTask::class.java) {
-                it.config.set(config)
-            }
         }
     }
 

--- a/src/main/kotlin/tech/harmonysoft/oss/gradle/dist/CustomGradleDistributionPlugin.kt
+++ b/src/main/kotlin/tech/harmonysoft/oss/gradle/dist/CustomGradleDistributionPlugin.kt
@@ -10,6 +10,9 @@ class CustomGradleDistributionPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
         val config = project.extensions.create("gradleDist", CustomGradleDistConfig::class.java)
+        config.customDistributionVersion.convention(
+            project.provider { project.version.toString() }
+        )
         project.tasks.register("buildGradleDist", BuildCustomGradleDistributionTask::class.java) {
             it.config.set(config)
         }

--- a/src/main/kotlin/tech/harmonysoft/oss/gradle/dist/CustomGradleDistributionPlugin.kt
+++ b/src/main/kotlin/tech/harmonysoft/oss/gradle/dist/CustomGradleDistributionPlugin.kt
@@ -11,9 +11,11 @@ class CustomGradleDistributionPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         val config = createAndConfigureExtension(project)
 
-        project.tasks.register("buildGradleDist", BuildCustomGradleDistributionTask::class.java) {
-            it.config.set(config)
-        }
+        project.tasks.register(
+            "buildGradleDist",
+            BuildCustomGradleDistributionTask::class.java,
+            config
+        )
         project.afterEvaluate {
             validateAndEnrich(config)
         }
@@ -28,6 +30,12 @@ class CustomGradleDistributionPlugin : Plugin<Project> {
             project.provider { project.version.toString() }
         )
         config.gradleDistributionType.convention("bin")
+        project.layout.projectDirectory.dir("src/main/resources/include").let {
+            if (it.asFile.exists()) config.utilityScriptsSourceDir.convention(it)
+        }
+        config.initScriptsSourceDir.convention(
+            project.layout.projectDirectory.dir("src/main/resources/init.d")
+        )
         config.skipContentExpansionFor.convention(emptyList())
         config.rootUrlMapper.convention(GradleUrlMapper { version, type ->
             "https://services.gradle.org/distributions/gradle-$version-${type}.zip"

--- a/src/main/kotlin/tech/harmonysoft/oss/gradle/dist/config/CustomGradleDistConfig.kt
+++ b/src/main/kotlin/tech/harmonysoft/oss/gradle/dist/config/CustomGradleDistConfig.kt
@@ -1,14 +1,42 @@
 package tech.harmonysoft.oss.gradle.dist.config
 
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
 
 interface CustomGradleDistConfig {
 
+    @get:Input
     val gradleVersion: Property<String>
+
+    @get:Optional
+    @get:Input
     val customDistributionName: Property<String>
+
+    @get:Optional
+    @get:Nested
     val customDistributionFileNameMapper: Property<CustomDistributionNameMapper>
+
+    @get:Input
     val customDistributionVersion: Property<String>
+
+    @get:Input
     val gradleDistributionType: Property<String>
+
+    @get:Optional
+    @get:InputDirectory
+    val utilityScriptsSourceDir: DirectoryProperty
+
+    @get:InputDirectory
+    val initScriptsSourceDir: DirectoryProperty
+
+    @get:Input
     val skipContentExpansionFor: Property<Collection<String>>
+
+    @get:Internal
     val rootUrlMapper: Property<GradleUrlMapper>
 }

--- a/src/test/kotlin/tech/harmonysoft/oss/gradle/dist/CustomGradleDistributionPluginTest.kt
+++ b/src/test/kotlin/tech/harmonysoft/oss/gradle/dist/CustomGradleDistributionPluginTest.kt
@@ -11,10 +11,12 @@ import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.CleanupMode
 import org.junit.jupiter.api.io.TempDir
 import tech.harmonysoft.oss.test.util.TestUtil.fail
+import java.nio.file.Paths
 
 class CustomGradleDistributionPluginTest {
 
@@ -543,7 +545,6 @@ class CustomGradleDistributionPluginTest {
         const val PROJECT_NAME = "my-project"
         const val PROJECT_VERSION = "1.0"
 
-        @field:TempDir(cleanup = CleanupMode.ON_SUCCESS)
         lateinit var DOWNLOAD_ROOT_DIR: Path
 
         @field:TempDir(cleanup = CleanupMode.ON_SUCCESS)
@@ -560,5 +561,15 @@ class CustomGradleDistributionPluginTest {
                 customDistributionName = "$PROJECT_NAME"
             }
         """.trimIndent()
+
+        @BeforeAll @JvmStatic fun setup() {
+            val downloadRootDir = System.getProperty("gradleDistTest.downloadRootDir")
+
+            if (downloadRootDir.isNullOrEmpty()) {
+                DOWNLOAD_ROOT_DIR = TESTS_ARTIFACTS_ROOT_DIR.resolve("gradle-download")
+            } else {
+                DOWNLOAD_ROOT_DIR = Paths.get(downloadRootDir)
+            }
+        }
     }
 }

--- a/src/test/kotlin/tech/harmonysoft/oss/gradle/dist/CustomGradleDistributionPluginTest.kt
+++ b/src/test/kotlin/tech/harmonysoft/oss/gradle/dist/CustomGradleDistributionPluginTest.kt
@@ -181,12 +181,12 @@ class CustomGradleDistributionPluginTest {
                 gradleVersion = "$GRADLE_VERSION"
                 customDistributionVersion = "$PROJECT_VERSION"
                 customDistributionName = "$PROJECT_NAME"
+                utilityScriptsSourceDir = project.layout.projectDirectory.dir("src/main/resources/own-include")
+                initScriptsSourceDir = project.layout.projectDirectory.dir("src/main/resources/own-init.d")
             }
             
             tasks.named<BuildCustomGradleDistributionTask>("buildGradleDist") {
-                includeRootDir = project.layout.projectDirectory.dir("src/main/resources/own-include")
-                extensionsRootDir = project.layout.projectDirectory.dir("src/main/resources/own-init.d")
-                customDistributionsRootDir = project.layout.buildDirectory.dir("own-gradle-dist")
+                customDistributionOutputDir = project.layout.buildDirectory.dir("own-gradle-dist")
             }
         """.trimIndent(), "build/own-gradle-dist")
         val expectedCustomDistributionFile = File(
@@ -444,7 +444,7 @@ class CustomGradleDistributionPluginTest {
     }
 
     private fun prepareGradleDistributionZip(projectRootDir: File) {
-        val downloadDir = File(projectRootDir, "build/download")
+        val downloadDir = File(projectRootDir, "build/gradle-download")
         Files.createDirectories(downloadDir.toPath())
         listOf("bin", "all").forEach {
             val zip = File(downloadDir, "gradle-${GRADLE_VERSION}-${it}.zip")

--- a/src/test/kotlin/tech/harmonysoft/oss/gradle/dist/CustomGradleDistributionPluginTest.kt
+++ b/src/test/kotlin/tech/harmonysoft/oss/gradle/dist/CustomGradleDistributionPluginTest.kt
@@ -51,6 +51,27 @@ class CustomGradleDistributionPluginTest {
     }
 
     @Test
+    fun `when custom single gradle distribution is built with project distribution version`() {
+        val testFiles = doTest("single-distribution-no-templates", """
+            plugins {
+                id("tech.harmonysoft.oss.custom-gradle-dist-plugin")
+            }
+            
+            version = "1.1"
+            
+            gradleDist {
+                gradleVersion = "$GRADLE_VERSION"
+                customDistributionName = "$PROJECT_NAME"
+            }
+        """.trimIndent())
+        val expectedCustomDistributionFile = File(
+            testFiles.inputRootDir,
+            "$BUILT_DISTS_DIR/gradle-$GRADLE_VERSION-$PROJECT_NAME-1.1-bin.zip"
+        )
+        verifyDistributionName(expectedCustomDistributionFile)
+    }
+
+    @Test
     fun `when cyclic expansion chain is detected then it is reported`() {
         try {
             doTest("cyclic-expansion-in-include-files")

--- a/src/test/kotlin/tech/harmonysoft/oss/gradle/dist/CustomGradleDistributionPluginTest.kt
+++ b/src/test/kotlin/tech/harmonysoft/oss/gradle/dist/CustomGradleDistributionPluginTest.kt
@@ -292,7 +292,7 @@ class CustomGradleDistributionPluginTest {
 
     @Test
     fun `when custom base gradle distribution mapper is defined in gradle groovy script then it's respected`() {
-        val customBaseGradleDistFile = Files.createTempFile("base-gradle-dist", "").toFile()
+        val customBaseGradleDistFile = Files.createTempFile(TESTS_ARTIFACTS_ROOT_DIR, "base-gradle-dist", "").toFile()
         createGradleDistributionZip(customBaseGradleDistFile)
         val testFiles = prepareInput("single-distribution-no-templates","""
             import tech.harmonysoft.oss.gradle.dist.config.GradleUrlMapper
@@ -315,7 +315,7 @@ class CustomGradleDistributionPluginTest {
 
     @Test
     fun `when custom base gradle distribution mapper is defined in gradle kotlin script then it's respected`() {
-        val customBaseGradleDistFile = Files.createTempFile("base-gradle-dist", "").toFile()
+        val customBaseGradleDistFile = Files.createTempFile(TESTS_ARTIFACTS_ROOT_DIR, "base-gradle-dist", "").toFile()
         createGradleDistributionZip(customBaseGradleDistFile)
         val testFiles = prepareInput("single-distribution-no-templates", """
             import tech.harmonysoft.oss.gradle.dist.config.GradleUrlMapper
@@ -363,9 +363,7 @@ class CustomGradleDistributionPluginTest {
     }
 
     private fun copy(dir: File): File {
-        val result = Files.createTempDirectory("${dir.name}-tmp").toFile().apply {
-            deleteOnExit()
-        }
+        val result = Files.createTempDirectory(TESTS_ARTIFACTS_ROOT_DIR, dir.name).toFile()
         val resourcesRoot = File(result, "src/main/resources")
         Files.createDirectories(resourcesRoot.toPath())
         dir.listFiles()?.forEach { child ->
@@ -484,7 +482,7 @@ class CustomGradleDistributionPluginTest {
             )
         }
         val zip = zips.first()
-        val rootUnzipDir = Files.createTempDirectory(zip.name).toFile()
+        val rootUnzipDir = Files.createTempDirectory(TESTS_ARTIFACTS_ROOT_DIR, zip.name).toFile()
         val zipFile = ZipFile(zip)
         for (zipEntry in zipFile.entries()) {
             val path = File(rootUnzipDir, zipEntry.name).toPath()
@@ -547,6 +545,9 @@ class CustomGradleDistributionPluginTest {
 
         @field:TempDir(cleanup = CleanupMode.ON_SUCCESS)
         lateinit var DOWNLOAD_ROOT_DIR: Path
+
+        @field:TempDir(cleanup = CleanupMode.ON_SUCCESS)
+        lateinit var TESTS_ARTIFACTS_ROOT_DIR: Path
 
         val BUILD_TEMPLATE = """
             plugins {

--- a/src/test/kotlin/tech/harmonysoft/oss/gradle/dist/CustomGradleDistributionPluginTest.kt
+++ b/src/test/kotlin/tech/harmonysoft/oss/gradle/dist/CustomGradleDistributionPluginTest.kt
@@ -12,6 +12,8 @@ import java.util.zip.ZipOutputStream
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.CleanupMode
+import org.junit.jupiter.api.io.TempDir
 import tech.harmonysoft.oss.test.util.TestUtil.fail
 
 class CustomGradleDistributionPluginTest {
@@ -524,7 +526,7 @@ class CustomGradleDistributionPluginTest {
     private fun runAndVerify(testFiles: TestFiles) {
         GradleRunner.create()
             .withProjectDir(testFiles.inputRootDir)
-            .withArguments("buildGradleDist", "--stacktrace")
+            .withArguments("buildGradleDist", "--stacktrace", "-PgradleDist.downloadRootDir=$DOWNLOAD_ROOT_DIR")
             .withPluginClasspath()
             .withDebug(true)
             .build()
@@ -542,6 +544,9 @@ class CustomGradleDistributionPluginTest {
         const val GRADLE_VERSION = "8.3"
         const val PROJECT_NAME = "my-project"
         const val PROJECT_VERSION = "1.0"
+
+        @field:TempDir(cleanup = CleanupMode.ON_SUCCESS)
+        lateinit var DOWNLOAD_ROOT_DIR: Path
 
         val BUILD_TEMPLATE = """
             plugins {

--- a/src/test/kotlin/tech/harmonysoft/oss/gradle/dist/CustomGradleDistributionPluginTest.kt
+++ b/src/test/kotlin/tech/harmonysoft/oss/gradle/dist/CustomGradleDistributionPluginTest.kt
@@ -149,7 +149,7 @@ class CustomGradleDistributionPluginTest {
 
     @Test
     fun `when custom single gradle distribution is built with non-default distribution type then it contains base distribution type`() {
-        val testFiles = withDistributionType("all").doTest("single-distribution-no-templates", """
+        val testFiles = doTest("single-distribution-no-templates", """
             plugins {
                 id("tech.harmonysoft.oss.custom-gradle-dist-plugin")
             }
@@ -208,7 +208,7 @@ class CustomGradleDistributionPluginTest {
 
     @Test
     fun `when multiple distributions are configured with non-default type then multiple distributions with correct names are created`() {
-        val testFiles = withDistributionType("all").doTest("multiple-distributions", """
+        val testFiles = doTest("multiple-distributions", """
             plugins {
                 id("tech.harmonysoft.oss.custom-gradle-dist-plugin")
             }
@@ -231,7 +231,7 @@ class CustomGradleDistributionPluginTest {
 
     @Test
     fun `when custom distribution file name mapper is configured in gradle groovy script then it is respected`() {
-        val testFiles = withDistributionType("all").prepareInput("single-distribution-no-templates", """
+        val testFiles = prepareInput("single-distribution-no-templates", """
             import tech.harmonysoft.oss.gradle.dist.config.CustomDistributionNameMapper
 
             plugins {
@@ -257,7 +257,7 @@ class CustomGradleDistributionPluginTest {
 
     @Test
     fun `when custom distribution file name mapper is configured in gradle kotlin script then it is respected`() {
-        val testFiles = withDistributionType("all").doTest("single-distribution-no-templates", """
+        val testFiles = doTest("single-distribution-no-templates", """
             import tech.harmonysoft.oss.gradle.dist.config.CustomDistributionNameMapper
             plugins {
                 id("tech.harmonysoft.oss.custom-gradle-dist-plugin")
@@ -446,8 +446,10 @@ class CustomGradleDistributionPluginTest {
     private fun prepareGradleDistributionZip(projectRootDir: File) {
         val downloadDir = File(projectRootDir, "build/download")
         Files.createDirectories(downloadDir.toPath())
-        val zip = File(downloadDir, "gradle-${GRADLE_VERSION}-${distributionType}.zip")
-        createGradleDistributionZip(zip)
+        listOf("bin", "all").forEach {
+            val zip = File(downloadDir, "gradle-${GRADLE_VERSION}-${it}.zip")
+            createGradleDistributionZip(zip)
+        }
     }
 
     private fun createGradleDistributionZip(zip: File) {
@@ -580,13 +582,6 @@ class CustomGradleDistributionPluginTest {
 
         verify(testFiles.expectedRootDir, File(testFiles.inputRootDir, buildDistsDir))
     }
-
-    private fun withDistributionType(type: String): CustomGradleDistributionPluginTest {
-        distributionType = type
-        return this
-    }
-
-    private var distributionType = DEFAULT_DISTRIBUTION_TYPE
 
     data class TestFiles(
         val inputRootDir: File,

--- a/src/test/resources/non-standard-directories/expected/init.d/mixin.gradle
+++ b/src/test/resources/non-standard-directories/expected/init.d/mixin.gradle
@@ -1,0 +1,5 @@
+initscript {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/src/test/resources/non-standard-directories/input/own-include/repository.gradle
+++ b/src/test/resources/non-standard-directories/input/own-include/repository.gradle
@@ -1,0 +1,3 @@
+repositories {
+    mavenCentral()
+}

--- a/src/test/resources/non-standard-directories/input/own-init.d/mixin.gradle
+++ b/src/test/resources/non-standard-directories/input/own-init.d/mixin.gradle
@@ -1,0 +1,3 @@
+initscript {
+    $repository$
+}


### PR DESCRIPTION
First of all, I have significantly improved test performance. Executing the tests performs from 6 to as long as 13 minutes (it probably depended on the load on the Gradle server, etc.). The first performance optimization was to separate a common directory where Gradle distributions were downloaded. This change alone reduced test execution time for me in the range from 2.5 to 3.5 minutes.

The next optimization was to disable deleting the directory with downloaded Gradle distributions, but in order not to clutter the developer's disk, I changed the directory location to a temporary one for the "Test" task. Executing `./gradlew clean` in the Project will also clear these files. This change has resulted in each subsequent test execution now taking only about 45 seconds. Much better and faster feedback than original!

I noticed that both the plug-in and the tests leave a lot of junk in the `/tmp` directory, which multicollectively led to disk space exhaustion in my case. I addressed this problem by setting aside a shared temporary directory, which is created and deleted by Jupiter.

In addition to the above, I have made changes that address issues #7 and #8. I myself badly need these changes to minimize configuration effort and to get easy access to generated custom Gradle distributions along with the ability to add libraries and plugins (including my own) as early as the build stage. I also added the missing `.gitignore` file with a very minimal set of exclusions.

I will be very grateful for the smooth integration of my changes into your project.